### PR TITLE
Service & availability updates

### DIFF
--- a/docs/provider_api_2.2/availability.md
+++ b/docs/provider_api_2.2/availability.md
@@ -124,12 +124,16 @@ Listan omfattar de fält som Availability definererar _utöver_ <a href="feasibi
                 <code>services / available</code>
             </td>
             <td>
-                Anger om/när teknisk tjänst är/blir tillgänglig för beställning och leverans. Om tjänsten inte kan levereras, exempelvis på grund av att den är upptagen av annan SP indikeras det med "NO" eller datum då tjänsten blir tillgänglig. Datumet får tidigast vara 1970-01-01.<br/>
+                Anger om/när teknisk tjänst är/blir tillgänglig för beställning och leverans.<br/>
+                Om tjänsten inte är tillgänglig för beställning av anropande TL skall det indikeras med "NO" eller datum då tjänsten blir tillgänglig.
+                <br/> Datumet får tidigast vara 1970-01-01.<br/>
                 <br/>
                 Innan tjänsten är tillgänglig första gången sammanfaller Available och Connection.<br/>
                 <br/>
                 <em>"YES", "NO" eller ISO-8601 datum (YYYY-MM-DD), obligatoriskt</em><br/>
-                Exempel: YES, NO, 2012-07-01
+                Exempel: YES, NO, 2012-07-01<br>
+                Exempel: Anropande TL har BB 10/10 aktivt. BB 10/10, BB 100/100 kan beställas om BB 10/10 först avaktiveras. KO skall svara med available YES.<br>
+                Exempel: Annan TL har BB 10/10 aktivt. BB 10/10, 100/100 skall svara med NO eller datum.
             </td>
         </tr>
         <tr>

--- a/docs/provider_api_2.2/availability.md
+++ b/docs/provider_api_2.2/availability.md
@@ -124,16 +124,12 @@ Listan omfattar de fält som Availability definererar _utöver_ <a href="feasibi
                 <code>services / available</code>
             </td>
             <td>
-                Anger om/när teknisk tjänst är/blir tillgänglig för beställning och leverans.<br/>
-                Om tjänsten inte är tillgänglig för beställning av anropande TL skall det indikeras med "NO" eller datum då tjänsten blir tillgänglig.
-                <br/> Datumet får tidigast vara 1970-01-01.<br/>
+                Anger om/när teknisk tjänst är/blir tillgänglig för beställning och leverans. Om tjänsten inte kan levereras, exempelvis på grund av att den är upptagen av annan SP indikeras det med "NO" eller datum då tjänsten blir tillgänglig. Datumet får tidigast vara 1970-01-01.<br/>
                 <br/>
                 Innan tjänsten är tillgänglig första gången sammanfaller Available och Connection.<br/>
                 <br/>
                 <em>"YES", "NO" eller ISO-8601 datum (YYYY-MM-DD), obligatoriskt</em><br/>
-                Exempel: YES, NO, 2012-07-01<br>
-                Exempel: Anropande TL har BB 10/10 aktivt. BB 10/10, BB 100/100 kan beställas om BB 10/10 först avaktiveras. KO skall svara med available YES.<br>
-                Exempel: Annan TL har BB 10/10 aktivt. BB 10/10, 100/100 skall svara med NO eller datum.
+                Exempel: YES, NO, 2012-07-01
             </td>
         </tr>
         <tr>

--- a/docs/provider_api_2.2/availability.md
+++ b/docs/provider_api_2.2/availability.md
@@ -29,6 +29,7 @@ Content-Type: application/json
     "mduDistinguisher": "12121212",
     "outlet": "A-11-14",
     "population": "Hemsöhem",
+    "cadastral": "Hemsö 123",
     "services": [
         {
             "service": "BB-100-100",

--- a/docs/provider_api_2.2/feasibility.md
+++ b/docs/provider_api_2.2/feasibility.md
@@ -28,6 +28,7 @@ Content-Type: application/json
         "mduDistinguisher": "12121212",
         "outlet": "A-11-14",
         "population": "Hemsöhem",
+        "cadastral": "Hemsö 123",
         "services": [
             {
                 "service": "BB-100-100",
@@ -174,6 +175,14 @@ Content-Type: application/json
             </td>
             <td>
                 Anger delbestånd i hela beståndet. Hela beståndet hämtas alltid in, men det kan filtreras och göras säljbart i olika etapper. <em>text</em>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <code>cadastral</code>
+            </td>
+            <td>
+                Anger fastighetsbeteckning. <em>text</em>
             </td>
         </tr>
         <tr>

--- a/docs/provider_api_2.2/service_activation.md
+++ b/docs/provider_api_2.2/service_activation.md
@@ -11,6 +11,7 @@ Content-Type: application/json
     "accessId": "STTA0001",
     "service": "BB-100-10",
     "operation": "ACTIVATE",
+    "provisioningType": "Start",
     "forcedTakeover": false,
     "customer": {
         "firstName": "Kalle",
@@ -114,6 +115,17 @@ Content-Type: application/json
             <td>
                Anger om tjänsten skall aktiveras, avaktiveras, suspenderas eller avsuspenderas.<br>
                Giltiga värden: "ACTIVATE", "DEACTIVATE", "SUSPEND", "UNSUSPEND". <em>text, obligatoriskt</em>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <code>provisioningType</code>
+            </td>
+            <td>
+               Anger vilken typ av affärsregler KOs system ska tillämpa (t.ex. för startavgifter).<br>
+               Giltiga värden: "Default", "Upgrade", "Downgrade", "Package", "Test". <br/>
+               Default eller tom sträng är normalfall. Upgrade och downgrade anges om tjänsten ska hanteras som en uppgradering eller nedgradering (KOs system har ansvar att se om detta är tillåtet). "Package" anger att detta ska hanteras som en del av ett paket (KOs system har ansvar att se om detta kan stämma). "Test" används då en ISP vill lägga på en tjänst för att temporärt testa en kunds anslutning och ska normalt inte ha med någon startavgift eller liknande (ansvar för borttagning av temporära tjänster ligger på tjänsteleverantören). 
+               <em>text</em>
             </td>
         </tr>
         <tr>

--- a/docs/provider_api_2.2/service_activation.md
+++ b/docs/provider_api_2.2/service_activation.md
@@ -112,8 +112,8 @@ Content-Type: application/json
                 <code>operation</code>
             </td>
             <td>
-               Anger om tjänsten skall aktiveras eller avaktiveras.<br>
-               Giltiga värden: "ACTIVATE", "DEACTIVATE". <em>text, obligatoriskt</em>
+               Anger om tjänsten skall aktiveras, avaktiveras, suspenderas eller avsuspenderas.<br>
+               Giltiga värden: "ACTIVATE", "DEACTIVATE", "SUSPEND", "UNSUSPEND". <em>text, obligatoriskt</em>
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
Lagt till stöd för:
billingId på tjänsteaktivering
Möjlighet att göra en suspend/unsuspend
Sätta provisionerinstyp som KO kan använda som guide för t.ex. avgifter

Lagt till fastighetsbeteckning (cadastral) i availability/feasability